### PR TITLE
Use empty value for $(VSTestTestAdapterPath) as default (relates to #10)

### DIFF
--- a/TeamCity.VSTest.TestLogger/TeamCity.VSTest.TestAdapter.props
+++ b/TeamCity.VSTest.TestLogger/TeamCity.VSTest.TestAdapter.props
@@ -6,7 +6,6 @@
 
     <PropertyGroup Condition=" '$(IsUnderTeamCity)' == 'true' ">
         <VSTestLogger Condition=" '$(VSTestLogger)' == '' ">logger://teamcity</VSTestLogger>
-        <VSTestTestAdapterPath Condition=" '$(VSTestTestAdapterPath)' == '' And !$(VSTestFramework.StartsWith('.NETFramework', StringComparison.OrdinalIgnoreCase)) ">.</VSTestTestAdapterPath>
     </PropertyGroup>
 
     <ItemGroup Condition=" '$(IsUnderTeamCity)' == 'true' and '$(MSBuildToolsVersion)' == '15.0' ">


### PR DESCRIPTION
In some cases, $(VSTestFramework) can be empty, because defined later.